### PR TITLE
feat: implement meeting analysis API endpoints with Redis caching

### DIFF
--- a/.kiro/specs/group-meeting-scheduler/tasks.md
+++ b/.kiro/specs/group-meeting-scheduler/tasks.md
@@ -62,7 +62,7 @@
   - Write API tests for file upload scenarios and error cases
   - _Requirements: 1.1, 1.3, 1.4, 6.4_
 
-- [ ] 8. Implement meeting analysis API endpoints
+- [x] 8. Implement meeting analysis API endpoints
 
   - Create POST /api/meetings/analyze endpoint for scheduling analysis
   - Build GET /api/calendars/[sessionId] for retrieving processed data

--- a/group-meeting-scheduler/package-lock.json
+++ b/group-meeting-scheduler/package-lock.json
@@ -8,6 +8,7 @@
       "name": "group-meeting-scheduler",
       "version": "0.1.0",
       "dependencies": {
+        "@upstash/redis": "^1.35.3",
         "@vercel/blob": "^1.1.1",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
@@ -2677,6 +2678,15 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.35.3",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.35.3.tgz",
+      "integrity": "sha512-hSjv66NOuahW3MisRGlSgoszU2uONAY2l5Qo3Sae8OT3/Tng9K+2/cBRuyPBX8egwEGcNNCF9+r0V6grNnhL+w==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
     },
     "node_modules/@vercel/blob": {
       "version": "1.1.1",
@@ -7467,6 +7477,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
     },
     "node_modules/undici": {
       "version": "5.29.0",

--- a/group-meeting-scheduler/package.json
+++ b/group-meeting-scheduler/package.json
@@ -11,6 +11,7 @@
     "test:run": "vitest run"
   },
   "dependencies": {
+    "@upstash/redis": "^1.35.3",
     "@vercel/blob": "^1.1.1",
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",

--- a/group-meeting-scheduler/src/app/api/calendars/[sessionId]/route.ts
+++ b/group-meeting-scheduler/src/app/api/calendars/[sessionId]/route.ts
@@ -15,7 +15,7 @@ export async function GET(
   const { sessionId } = await params;
 
   try {
-    const session = getUploadSession(sessionId);
+    const session = await getUploadSession(sessionId);
 
     if (!session) {
       return NextResponse.json<ErrorResponse>(
@@ -136,7 +136,7 @@ export async function DELETE(
   const { sessionId } = await params;
 
   try {
-    const session = getUploadSession(sessionId);
+    const session = await getUploadSession(sessionId);
 
     if (!session) {
       return NextResponse.json<ErrorResponse>(
@@ -157,8 +157,8 @@ export async function DELETE(
     }
 
     // TODO: In production, also clean up Vercel Blob files
-    // For now, just delete the session from memory
-    const deleted = deleteUploadSession(sessionId);
+    // Delete the session from cache/memory
+    const deleted = await deleteUploadSession(sessionId);
 
     if (!deleted) {
       return NextResponse.json<ErrorResponse>(

--- a/group-meeting-scheduler/src/app/api/calendars/upload/route.ts
+++ b/group-meeting-scheduler/src/app/api/calendars/upload/route.ts
@@ -62,7 +62,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Create a new upload session
-    const session = createUploadSession();
+    const session = await createUploadSession();
     const uploadErrors: string[] = [];
     const participants: ParticipantCalendar[] = [];
     let earliestDate: Date | null = null;
@@ -88,7 +88,7 @@ export async function POST(request: NextRequest) {
             processed: false,
             errors: validation.errors,
           };
-          addUploadedFileToSession(session.id, uploadedFile);
+          await addUploadedFileToSession(session.id, uploadedFile);
           continue;
         }
 
@@ -112,7 +112,7 @@ export async function POST(request: NextRequest) {
             processed: false,
             errors: contentValidation.errors,
           };
-          addUploadedFileToSession(session.id, uploadedFile);
+          await addUploadedFileToSession(session.id, uploadedFile);
           continue;
         }
 
@@ -139,7 +139,7 @@ export async function POST(request: NextRequest) {
         };
 
         // Add file to session
-        addUploadedFileToSession(session.id, uploadedFile);
+        await addUploadedFileToSession(session.id, uploadedFile);
 
         // Parse iCal content
         try {
@@ -149,7 +149,7 @@ export async function POST(request: NextRequest) {
           );
 
           participants.push(participant);
-          addParticipantToSession(session.id, participant);
+          await addParticipantToSession(session.id, participant);
 
           // Update date range
           if (participant.events.length > 0) {

--- a/group-meeting-scheduler/src/app/api/meetings/analyze/route.ts
+++ b/group-meeting-scheduler/src/app/api/meetings/analyze/route.ts
@@ -1,0 +1,295 @@
+import { NextRequest, NextResponse } from "next/server";
+import { v4 as uuidv4 } from "uuid";
+import { getUploadSession } from "@/lib/upload-session";
+import { MeetingScheduler } from "@/lib/meeting-scheduler";
+import { redisCache } from "@/lib/redis-cache";
+import {
+  ErrorResponse,
+  MeetingAnalysisRequest,
+  MeetingAnalysisResponse,
+} from "@/types/api";
+import { MeetingPreferences } from "@/types/scheduling";
+import { addDays, startOfDay, endOfDay } from "date-fns";
+
+/**
+ * POST /api/meetings/analyze
+ * Analyze calendars and find optimal meeting times
+ */
+export async function POST(request: NextRequest) {
+  const requestId = uuidv4();
+  const startTime = Date.now();
+
+  try {
+    const body: MeetingAnalysisRequest = await request.json();
+    const { sessionId, preferences } = body;
+
+    // Validate request body
+    if (!sessionId || !preferences) {
+      return NextResponse.json<ErrorResponse>(
+        {
+          error: {
+            code: "INVALID_REQUEST",
+            message: "Missing required fields: sessionId and preferences",
+            suggestions: [
+              "Ensure sessionId is provided",
+              "Ensure preferences object is provided with duration, timeRangeStart, timeRangeEnd",
+            ],
+          },
+          timestamp: new Date().toISOString(),
+          requestId,
+        },
+        { status: 400 }
+      );
+    }
+
+    // Validate preferences
+    const validationError = validateMeetingPreferences(preferences);
+    if (validationError) {
+      return NextResponse.json<ErrorResponse>(
+        {
+          error: {
+            code: "INVALID_PREFERENCES",
+            message: validationError,
+            suggestions: [
+              "Check that duration is a positive number",
+              "Ensure time ranges are in HH:MM format",
+              "Verify that timeRangeStart is before timeRangeEnd",
+            ],
+          },
+          timestamp: new Date().toISOString(),
+          requestId,
+        },
+        { status: 400 }
+      );
+    }
+
+    // Get session data
+    const session = await getUploadSession(sessionId);
+    if (!session) {
+      return NextResponse.json<ErrorResponse>(
+        {
+          error: {
+            code: "SESSION_NOT_FOUND",
+            message: "Upload session not found or expired",
+            suggestions: [
+              "Check that the session ID is correct",
+              "Upload your files again if the session has expired",
+              "Sessions expire after 24 hours",
+            ],
+          },
+          timestamp: new Date().toISOString(),
+          requestId,
+        },
+        { status: 404 }
+      );
+    }
+
+    // Check if session has participants
+    if (!session.participants || session.participants.length === 0) {
+      return NextResponse.json<ErrorResponse>(
+        {
+          error: {
+            code: "NO_PARTICIPANTS",
+            message: "No participants found in session",
+            suggestions: [
+              "Upload calendar files first",
+              "Ensure calendar files were processed successfully",
+            ],
+          },
+          timestamp: new Date().toISOString(),
+          requestId,
+        },
+        { status: 400 }
+      );
+    }
+
+    // Determine search range based on calendar data
+    const searchRange = calculateSearchRange(session.participants);
+    if (!searchRange) {
+      return NextResponse.json<ErrorResponse>(
+        {
+          error: {
+            code: "NO_CALENDAR_DATA",
+            message: "No calendar events found to analyze",
+            suggestions: [
+              "Ensure uploaded calendar files contain events",
+              "Check that calendar files are not empty",
+            ],
+          },
+          timestamp: new Date().toISOString(),
+          requestId,
+        },
+        { status: 400 }
+      );
+    }
+
+    // Initialize meeting scheduler
+    const scheduler = new MeetingScheduler();
+
+    // Perform scheduling analysis
+    const results = await scheduler.scheduleOptimalMeeting(
+      session.participants,
+      preferences,
+      searchRange
+    );
+
+    // Store scheduling session with results
+    const schedulingSession: import("@/types/scheduling").SchedulingSession = {
+      id: sessionId,
+      createdAt: session.createdAt,
+      expiresAt: session.expiresAt,
+      participants: session.participants,
+      preferences,
+      results,
+    };
+
+    // Store in Redis cache
+    if (redisCache.isAvailable()) {
+      await redisCache.setSchedulingSession(sessionId, schedulingSession);
+    }
+
+    const processingTime = Date.now() - startTime;
+
+    const response: MeetingAnalysisResponse = {
+      sessionId,
+      results,
+      processingTime,
+    };
+
+    return NextResponse.json(response);
+  } catch (error) {
+    console.error("Meeting analysis error:", error);
+
+    // Handle specific scheduling errors
+    if (error instanceof Error && error.name === "SchedulingError") {
+      return NextResponse.json<ErrorResponse>(
+        {
+          error: {
+            code: (error as any).code || "SCHEDULING_ERROR",
+            message: error.message,
+            suggestions: [
+              "Try adjusting meeting preferences",
+              "Consider expanding the time range",
+              "Check if participants have availability",
+            ],
+          },
+          timestamp: new Date().toISOString(),
+          requestId,
+        },
+        { status: 400 }
+      );
+    }
+
+    return NextResponse.json<ErrorResponse>(
+      {
+        error: {
+          code: "ANALYSIS_FAILED",
+          message: "Failed to analyze meeting availability",
+          details: {
+            error: error instanceof Error ? error.message : "Unknown error",
+          },
+          suggestions: [
+            "Try the analysis again",
+            "Check that all calendar data is valid",
+            "Contact support if the problem persists",
+          ],
+        },
+        timestamp: new Date().toISOString(),
+        requestId,
+      },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * Validates meeting preferences
+ */
+function validateMeetingPreferences(
+  preferences: MeetingPreferences
+): string | null {
+  if (!preferences.duration || preferences.duration <= 0) {
+    return "Duration must be a positive number";
+  }
+
+  if (preferences.duration > 8 * 60) {
+    return "Duration cannot exceed 8 hours (480 minutes)";
+  }
+
+  const timeRegex = /^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$/;
+  if (!timeRegex.test(preferences.timeRangeStart)) {
+    return "timeRangeStart must be in HH:MM format";
+  }
+
+  if (!timeRegex.test(preferences.timeRangeEnd)) {
+    return "timeRangeEnd must be in HH:MM format";
+  }
+
+  // Parse times to compare
+  const [startHour, startMinute] = preferences.timeRangeStart
+    .split(":")
+    .map(Number);
+  const [endHour, endMinute] = preferences.timeRangeEnd.split(":").map(Number);
+
+  const startMinutes = startHour * 60 + startMinute;
+  const endMinutes = endHour * 60 + endMinute;
+
+  if (startMinutes >= endMinutes) {
+    return "timeRangeStart must be before timeRangeEnd";
+  }
+
+  if (preferences.bufferTime < 0) {
+    return "bufferTime cannot be negative";
+  }
+
+  if (preferences.bufferTime > 60) {
+    return "bufferTime cannot exceed 60 minutes";
+  }
+
+  return null;
+}
+
+/**
+ * Calculates appropriate search range based on participant calendar data
+ */
+function calculateSearchRange(
+  participants: import("@/types/calendar").ParticipantCalendar[]
+): { start: Date; end: Date } | null {
+  let earliestDate: Date | null = null;
+  let latestDate: Date | null = null;
+
+  // Find the date range from all participants' events
+  for (const participant of participants) {
+    if (participant.events.length > 0) {
+      const eventDates = participant.events.flatMap((e) => [e.start, e.end]);
+      const minDate = new Date(Math.min(...eventDates.map((d) => d.getTime())));
+      const maxDate = new Date(Math.max(...eventDates.map((d) => d.getTime())));
+
+      if (!earliestDate || minDate < earliestDate) {
+        earliestDate = minDate;
+      }
+      if (!latestDate || maxDate > latestDate) {
+        latestDate = maxDate;
+      }
+    }
+  }
+
+  if (!earliestDate || !latestDate) {
+    return null;
+  }
+
+  // Extend the search range to include some buffer
+  // Start from today or the earliest event date, whichever is later
+  const today = startOfDay(new Date());
+  const searchStart = earliestDate > today ? startOfDay(earliestDate) : today;
+
+  // End 30 days from start or at the latest event date, whichever is later
+  const defaultEnd = addDays(searchStart, 30);
+  const searchEnd =
+    latestDate > defaultEnd ? endOfDay(latestDate) : endOfDay(defaultEnd);
+
+  return {
+    start: searchStart,
+    end: searchEnd,
+  };
+}

--- a/group-meeting-scheduler/src/lib/__tests__/file-upload-api.test.ts
+++ b/group-meeting-scheduler/src/lib/__tests__/file-upload-api.test.ts
@@ -362,8 +362,8 @@ describe("Upload Session Management", () => {
       "@/lib/upload-session"
     );
 
-    const session = createUploadSession();
-    const retrieved = getUploadSession(session.id);
+    const session = await createUploadSession();
+    const retrieved = await getUploadSession(session.id);
 
     expect(retrieved).toBeDefined();
     expect(retrieved?.id).toBe(session.id);
@@ -374,7 +374,7 @@ describe("Upload Session Management", () => {
   it("should return null for non-existent sessions", async () => {
     const { getUploadSession } = await import("@/lib/upload-session");
 
-    const result = getUploadSession("non-existent-id");
+    const result = await getUploadSession("non-existent-id");
     expect(result).toBeNull();
   });
 
@@ -382,11 +382,11 @@ describe("Upload Session Management", () => {
     const { createUploadSession, getUploadSession, deleteUploadSession } =
       await import("@/lib/upload-session");
 
-    const session = createUploadSession();
-    expect(getUploadSession(session.id)).toBeDefined();
+    const session = await createUploadSession();
+    expect(await getUploadSession(session.id)).toBeDefined();
 
-    const deleted = deleteUploadSession(session.id);
+    const deleted = await deleteUploadSession(session.id);
     expect(deleted).toBe(true);
-    expect(getUploadSession(session.id)).toBeNull();
+    expect(await getUploadSession(session.id)).toBeNull();
   });
 });

--- a/group-meeting-scheduler/src/lib/__tests__/meeting-analysis-api.test.ts
+++ b/group-meeting-scheduler/src/lib/__tests__/meeting-analysis-api.test.ts
@@ -1,0 +1,478 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/meetings/analyze/route";
+import { GET, DELETE } from "@/app/api/calendars/[sessionId]/route";
+import {
+  createUploadSession,
+  addParticipantToSession,
+} from "@/lib/upload-session";
+import { ParticipantCalendar } from "@/types/calendar";
+import { MeetingAnalysisRequest } from "@/types/api";
+
+// Mock Redis cache
+vi.mock("@/lib/redis-cache", () => ({
+  redisCache: {
+    isAvailable: () => false,
+    setSchedulingSession: vi.fn(),
+    getSchedulingSession: vi.fn(),
+    deleteSchedulingSession: vi.fn(),
+  },
+}));
+
+// Mock MeetingScheduler
+vi.mock("@/lib/meeting-scheduler", () => ({
+  MeetingScheduler: vi.fn().mockImplementation(() => ({
+    scheduleOptimalMeeting: vi.fn().mockResolvedValue({
+      availableSlots: [
+        {
+          start: new Date("2024-01-15T10:00:00Z"),
+          end: new Date("2024-01-15T11:00:00Z"),
+          score: 95,
+          conflicts: [],
+          timezoneDisplay: {
+            "America/New_York": "Jan 15, 10:00 AM - 11:00 AM",
+            "Europe/London": "Jan 15, 3:00 PM - 4:00 PM",
+          },
+        },
+        {
+          start: new Date("2024-01-15T14:00:00Z"),
+          end: new Date("2024-01-15T15:00:00Z"),
+          score: 88,
+          conflicts: [],
+          timezoneDisplay: {
+            "America/New_York": "Jan 15, 2:00 PM - 3:00 PM",
+            "Europe/London": "Jan 15, 7:00 PM - 8:00 PM",
+          },
+        },
+      ],
+      conflictAnalysis: {
+        totalConflicts: 0,
+        participantConflicts: {},
+        conflictsByTimeSlot: {},
+      },
+      recommendations: [
+        {
+          start: new Date("2024-01-15T10:00:00Z"),
+          end: new Date("2024-01-15T11:00:00Z"),
+          score: 95,
+          conflicts: [],
+          timezoneDisplay: {
+            "America/New_York": "Jan 15, 10:00 AM - 11:00 AM",
+            "Europe/London": "Jan 15, 3:00 PM - 4:00 PM",
+          },
+        },
+      ],
+    }),
+  })),
+}));
+
+describe("Meeting Analysis API", () => {
+  let sessionId: string;
+  let mockParticipants: ParticipantCalendar[];
+
+  beforeEach(async () => {
+    // Create test session with participants
+    const session = await createUploadSession();
+    sessionId = session.id;
+
+    mockParticipants = [
+      {
+        participantId: "participant-1",
+        name: "John Doe",
+        timezone: "America/New_York",
+        source: "ical",
+        events: [
+          {
+            id: "event-1",
+            summary: "Existing Meeting",
+            start: new Date("2024-01-15T09:00:00Z"),
+            end: new Date("2024-01-15T09:30:00Z"),
+            timezone: "America/New_York",
+            status: "confirmed",
+          },
+        ],
+      },
+      {
+        participantId: "participant-2",
+        name: "Jane Smith",
+        timezone: "Europe/London",
+        source: "ical",
+        events: [
+          {
+            id: "event-2",
+            summary: "Team Standup",
+            start: new Date("2024-01-15T08:00:00Z"),
+            end: new Date("2024-01-15T08:30:00Z"),
+            timezone: "Europe/London",
+            status: "confirmed",
+          },
+        ],
+      },
+    ];
+
+    // Add participants to session
+    for (const participant of mockParticipants) {
+      await addParticipantToSession(sessionId, participant);
+    }
+  });
+
+  describe("POST /api/meetings/analyze", () => {
+    it("should analyze meeting availability successfully", async () => {
+      const requestBody: MeetingAnalysisRequest = {
+        sessionId,
+        preferences: {
+          duration: 60,
+          timeRangeStart: "09:00",
+          timeRangeEnd: "17:00",
+          excludeWeekends: true,
+          excludedDates: [],
+          bufferTime: 0,
+          preferredTimezones: ["America/New_York"],
+        },
+      };
+
+      const request = new NextRequest(
+        "http://localhost:3000/api/meetings/analyze",
+        {
+          method: "POST",
+          body: JSON.stringify(requestBody),
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data).toHaveProperty("sessionId", sessionId);
+      expect(data).toHaveProperty("results");
+      expect(data).toHaveProperty("processingTime");
+      expect(data.results).toHaveProperty("availableSlots");
+      expect(data.results).toHaveProperty("conflictAnalysis");
+      expect(data.results).toHaveProperty("recommendations");
+      expect(Array.isArray(data.results.availableSlots)).toBe(true);
+      expect(data.results.availableSlots.length).toBeGreaterThan(0);
+    });
+
+    it("should return error for invalid session ID", async () => {
+      const requestBody: MeetingAnalysisRequest = {
+        sessionId: "invalid-session-id",
+        preferences: {
+          duration: 60,
+          timeRangeStart: "09:00",
+          timeRangeEnd: "17:00",
+          excludeWeekends: true,
+          excludedDates: [],
+          bufferTime: 0,
+          preferredTimezones: [],
+        },
+      };
+
+      const request = new NextRequest(
+        "http://localhost:3000/api/meetings/analyze",
+        {
+          method: "POST",
+          body: JSON.stringify(requestBody),
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.error.code).toBe("SESSION_NOT_FOUND");
+    });
+
+    it("should return error for missing request body", async () => {
+      const request = new NextRequest(
+        "http://localhost:3000/api/meetings/analyze",
+        {
+          method: "POST",
+          body: JSON.stringify({}),
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error.code).toBe("INVALID_REQUEST");
+    });
+
+    it("should return error for invalid preferences", async () => {
+      const requestBody = {
+        sessionId,
+        preferences: {
+          duration: -30, // Invalid negative duration
+          timeRangeStart: "25:00", // Invalid time format
+          timeRangeEnd: "17:00",
+          excludeWeekends: true,
+          excludedDates: [],
+          bufferTime: 0,
+          preferredTimezones: [],
+        },
+      };
+
+      const request = new NextRequest(
+        "http://localhost:3000/api/meetings/analyze",
+        {
+          method: "POST",
+          body: JSON.stringify(requestBody),
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error.code).toBe("INVALID_PREFERENCES");
+    });
+
+    it("should validate time range order", async () => {
+      const requestBody = {
+        sessionId,
+        preferences: {
+          duration: 60,
+          timeRangeStart: "17:00", // Start after end
+          timeRangeEnd: "09:00",
+          excludeWeekends: true,
+          excludedDates: [],
+          bufferTime: 0,
+          preferredTimezones: [],
+        },
+      };
+
+      const request = new NextRequest(
+        "http://localhost:3000/api/meetings/analyze",
+        {
+          method: "POST",
+          body: JSON.stringify(requestBody),
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error.code).toBe("INVALID_PREFERENCES");
+      expect(data.error.message).toContain(
+        "timeRangeStart must be before timeRangeEnd"
+      );
+    });
+
+    it("should validate duration limits", async () => {
+      const requestBody = {
+        sessionId,
+        preferences: {
+          duration: 600, // 10 hours - exceeds limit
+          timeRangeStart: "09:00",
+          timeRangeEnd: "17:00",
+          excludeWeekends: true,
+          excludedDates: [],
+          bufferTime: 0,
+          preferredTimezones: [],
+        },
+      };
+
+      const request = new NextRequest(
+        "http://localhost:3000/api/meetings/analyze",
+        {
+          method: "POST",
+          body: JSON.stringify(requestBody),
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error.code).toBe("INVALID_PREFERENCES");
+      expect(data.error.message).toContain("Duration cannot exceed 8 hours");
+    });
+  });
+
+  describe("GET /api/calendars/[sessionId]", () => {
+    it("should retrieve session data successfully", async () => {
+      const request = new NextRequest(
+        `http://localhost:3000/api/calendars/${sessionId}`
+      );
+      const params = Promise.resolve({ sessionId });
+
+      const response = await GET(request, { params });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data).toHaveProperty("sessionId", sessionId);
+      expect(data).toHaveProperty("participantCount", 2);
+      expect(data).toHaveProperty("participants");
+      expect(Array.isArray(data.participants)).toBe(true);
+      expect(data.participants).toHaveLength(2);
+    });
+
+    it("should return error for non-existent session", async () => {
+      const invalidSessionId = "non-existent-session";
+      const request = new NextRequest(
+        `http://localhost:3000/api/calendars/${invalidSessionId}`
+      );
+      const params = Promise.resolve({ sessionId: invalidSessionId });
+
+      const response = await GET(request, { params });
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.error.code).toBe("SESSION_NOT_FOUND");
+    });
+  });
+
+  describe("DELETE /api/calendars/[sessionId]", () => {
+    it("should delete session successfully", async () => {
+      const request = new NextRequest(
+        `http://localhost:3000/api/calendars/${sessionId}`,
+        {
+          method: "DELETE",
+        }
+      );
+      const params = Promise.resolve({ sessionId });
+
+      const response = await DELETE(request, { params });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data).toHaveProperty("message", "Session deleted successfully");
+      expect(data).toHaveProperty("sessionId", sessionId);
+    });
+
+    it("should return error when trying to delete non-existent session", async () => {
+      const invalidSessionId = "non-existent-session";
+      const request = new NextRequest(
+        `http://localhost:3000/api/calendars/${invalidSessionId}`,
+        {
+          method: "DELETE",
+        }
+      );
+      const params = Promise.resolve({ sessionId: invalidSessionId });
+
+      const response = await DELETE(request, { params });
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.error.code).toBe("SESSION_NOT_FOUND");
+    });
+
+    it("should verify session is actually deleted", async () => {
+      // First delete the session
+      const deleteRequest = new NextRequest(
+        `http://localhost:3000/api/calendars/${sessionId}`,
+        {
+          method: "DELETE",
+        }
+      );
+      const deleteParams = Promise.resolve({ sessionId });
+      await DELETE(deleteRequest, { params: deleteParams });
+
+      // Then try to retrieve it
+      const getRequest = new NextRequest(
+        `http://localhost:3000/api/calendars/${sessionId}`
+      );
+      const getParams = Promise.resolve({ sessionId });
+      const response = await GET(getRequest, { params: getParams });
+
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe("Edge Cases", () => {
+    it("should handle session with no participants", async () => {
+      const emptySession = await createUploadSession();
+      const requestBody: MeetingAnalysisRequest = {
+        sessionId: emptySession.id,
+        preferences: {
+          duration: 60,
+          timeRangeStart: "09:00",
+          timeRangeEnd: "17:00",
+          excludeWeekends: true,
+          excludedDates: [],
+          bufferTime: 0,
+          preferredTimezones: [],
+        },
+      };
+
+      const request = new NextRequest(
+        "http://localhost:3000/api/meetings/analyze",
+        {
+          method: "POST",
+          body: JSON.stringify(requestBody),
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error.code).toBe("NO_PARTICIPANTS");
+    });
+
+    it("should handle participants with no events", async () => {
+      const emptySession = await createUploadSession();
+      const emptyParticipant: ParticipantCalendar = {
+        participantId: "empty-participant",
+        name: "Empty Calendar",
+        timezone: "America/New_York",
+        source: "ical",
+        events: [], // No events
+      };
+
+      await addParticipantToSession(emptySession.id, emptyParticipant);
+
+      const requestBody: MeetingAnalysisRequest = {
+        sessionId: emptySession.id,
+        preferences: {
+          duration: 60,
+          timeRangeStart: "09:00",
+          timeRangeEnd: "17:00",
+          excludeWeekends: true,
+          excludedDates: [],
+          bufferTime: 0,
+          preferredTimezones: [],
+        },
+      };
+
+      const request = new NextRequest(
+        "http://localhost:3000/api/meetings/analyze",
+        {
+          method: "POST",
+          body: JSON.stringify(requestBody),
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error.code).toBe("NO_CALENDAR_DATA");
+    });
+  });
+});

--- a/group-meeting-scheduler/src/lib/__tests__/redis-cache.test.ts
+++ b/group-meeting-scheduler/src/lib/__tests__/redis-cache.test.ts
@@ -1,0 +1,367 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { RedisCache } from "@/lib/redis-cache";
+import { UploadSession } from "@/lib/upload-session";
+import { SchedulingSession } from "@/types/scheduling";
+import { ParticipantCalendar } from "@/types/calendar";
+
+// Mock Upstash Redis
+const mockRedis = {
+  setex: vi.fn(),
+  get: vi.fn(),
+  del: vi.fn(),
+  expire: vi.fn(),
+  keys: vi.fn(),
+  ping: vi.fn(),
+};
+
+vi.mock("@upstash/redis", () => ({
+  Redis: vi.fn().mockImplementation(() => mockRedis),
+}));
+
+describe("RedisCache", () => {
+  let redisCache: RedisCache;
+  let mockUploadSession: UploadSession;
+  let mockSchedulingSession: SchedulingSession;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Mock environment variables
+    process.env.UPSTASH_REDIS_REST_URL = "https://test-redis.upstash.io";
+    process.env.UPSTASH_REDIS_REST_TOKEN = "test-token";
+
+    redisCache = new RedisCache();
+
+    mockUploadSession = {
+      id: "test-session-id",
+      createdAt: new Date("2024-01-15T10:00:00Z"),
+      expiresAt: new Date("2024-01-16T10:00:00Z"),
+      participants: [
+        {
+          participantId: "participant-1",
+          name: "John Doe",
+          timezone: "America/New_York",
+          source: "ical",
+          events: [
+            {
+              id: "event-1",
+              summary: "Test Event",
+              start: new Date("2024-01-15T14:00:00Z"),
+              end: new Date("2024-01-15T15:00:00Z"),
+              timezone: "America/New_York",
+              status: "confirmed",
+            },
+          ],
+        },
+      ],
+      uploadedFiles: [
+        {
+          id: "file-1",
+          originalName: "calendar.ics",
+          blobUrl: "https://blob.vercel-storage.com/test-file",
+          size: 1024,
+          uploadedAt: new Date("2024-01-15T10:00:00Z"),
+          processed: true,
+        },
+      ],
+    };
+
+    mockSchedulingSession = {
+      id: "test-session-id",
+      createdAt: new Date("2024-01-15T10:00:00Z"),
+      expiresAt: new Date("2024-01-16T10:00:00Z"),
+      participants: mockUploadSession.participants,
+      preferences: {
+        duration: 60,
+        timeRangeStart: "09:00",
+        timeRangeEnd: "17:00",
+        excludeWeekends: true,
+        excludedDates: [],
+        bufferTime: 0,
+        preferredTimezones: ["America/New_York"],
+      },
+      results: {
+        availableSlots: [
+          {
+            start: new Date("2024-01-15T16:00:00Z"),
+            end: new Date("2024-01-15T17:00:00Z"),
+            score: 95,
+            conflicts: [],
+            timezoneDisplay: {
+              "America/New_York": "Jan 15, 12:00 PM - 1:00 PM",
+            },
+          },
+        ],
+        conflictAnalysis: {
+          totalConflicts: 0,
+          participantConflicts: {},
+          conflictsByTimeSlot: {},
+        },
+        recommendations: [
+          {
+            start: new Date("2024-01-15T16:00:00Z"),
+            end: new Date("2024-01-15T17:00:00Z"),
+            score: 95,
+            conflicts: [],
+            timezoneDisplay: {
+              "America/New_York": "Jan 15, 12:00 PM - 1:00 PM",
+            },
+          },
+        ],
+      },
+    };
+  });
+
+  describe("isAvailable", () => {
+    it("should return true when Redis is configured", () => {
+      expect(redisCache.isAvailable()).toBe(true);
+    });
+
+    it("should return false when Redis is not configured", () => {
+      delete process.env.UPSTASH_REDIS_REST_URL;
+      delete process.env.UPSTASH_REDIS_REST_TOKEN;
+
+      const cacheWithoutRedis = new RedisCache();
+      expect(cacheWithoutRedis.isAvailable()).toBe(false);
+    });
+  });
+
+  describe("Upload Session Operations", () => {
+    it("should store upload session successfully", async () => {
+      mockRedis.setex.mockResolvedValue("OK");
+
+      const result = await redisCache.setUploadSession(
+        "test-session-id",
+        mockUploadSession
+      );
+
+      expect(result).toBe(true);
+      expect(mockRedis.setex).toHaveBeenCalledWith(
+        "upload_session:test-session-id",
+        24 * 60 * 60, // 24 hours in seconds
+        expect.stringContaining('"id":"test-session-id"')
+      );
+    });
+
+    it("should retrieve upload session successfully", async () => {
+      const serializedSession = JSON.stringify({
+        ...mockUploadSession,
+        createdAt: mockUploadSession.createdAt.toISOString(),
+        expiresAt: mockUploadSession.expiresAt.toISOString(),
+        participants: mockUploadSession.participants.map((p) => ({
+          ...p,
+          events: p.events.map((e) => ({
+            ...e,
+            start: e.start.toISOString(),
+            end: e.end.toISOString(),
+          })),
+        })),
+        uploadedFiles: mockUploadSession.uploadedFiles.map((f) => ({
+          ...f,
+          uploadedAt: f.uploadedAt.toISOString(),
+        })),
+      });
+
+      mockRedis.get.mockResolvedValue(serializedSession);
+
+      const result = await redisCache.getUploadSession("test-session-id");
+
+      expect(result).toBeDefined();
+      expect(result?.id).toBe("test-session-id");
+      expect(result?.createdAt).toBeInstanceOf(Date);
+      expect(result?.participants[0].events[0].start).toBeInstanceOf(Date);
+      expect(mockRedis.get).toHaveBeenCalledWith(
+        "upload_session:test-session-id"
+      );
+    });
+
+    it("should return null when session not found", async () => {
+      mockRedis.get.mockResolvedValue(null);
+
+      const result = await redisCache.getUploadSession("non-existent-session");
+
+      expect(result).toBeNull();
+    });
+
+    it("should delete upload session successfully", async () => {
+      mockRedis.del.mockResolvedValue(1);
+
+      const result = await redisCache.deleteUploadSession("test-session-id");
+
+      expect(result).toBe(true);
+      expect(mockRedis.del).toHaveBeenCalledWith(
+        "upload_session:test-session-id"
+      );
+    });
+
+    it("should handle Redis errors gracefully", async () => {
+      mockRedis.setex.mockRejectedValue(new Error("Redis connection failed"));
+
+      const result = await redisCache.setUploadSession(
+        "test-session-id",
+        mockUploadSession
+      );
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("Scheduling Session Operations", () => {
+    it("should store scheduling session successfully", async () => {
+      mockRedis.setex.mockResolvedValue("OK");
+
+      const result = await redisCache.setSchedulingSession(
+        "test-session-id",
+        mockSchedulingSession
+      );
+
+      expect(result).toBe(true);
+      expect(mockRedis.setex).toHaveBeenCalledWith(
+        "scheduling_session:test-session-id",
+        24 * 60 * 60, // 24 hours in seconds
+        expect.stringContaining('"id":"test-session-id"')
+      );
+    });
+
+    it("should retrieve scheduling session successfully", async () => {
+      const serializedSession = JSON.stringify({
+        ...mockSchedulingSession,
+        createdAt: mockSchedulingSession.createdAt.toISOString(),
+        expiresAt: mockSchedulingSession.expiresAt.toISOString(),
+        participants: mockSchedulingSession.participants.map((p) => ({
+          ...p,
+          events: p.events.map((e) => ({
+            ...e,
+            start: e.start.toISOString(),
+            end: e.end.toISOString(),
+          })),
+        })),
+        preferences: {
+          ...mockSchedulingSession.preferences,
+          excludedDates: mockSchedulingSession.preferences.excludedDates.map(
+            (d) => d.toISOString()
+          ),
+        },
+        results: {
+          ...mockSchedulingSession.results!,
+          availableSlots: mockSchedulingSession.results!.availableSlots.map(
+            (slot) => ({
+              ...slot,
+              start: slot.start.toISOString(),
+              end: slot.end.toISOString(),
+            })
+          ),
+          recommendations: mockSchedulingSession.results!.recommendations.map(
+            (slot) => ({
+              ...slot,
+              start: slot.start.toISOString(),
+              end: slot.end.toISOString(),
+            })
+          ),
+        },
+      });
+
+      mockRedis.get.mockResolvedValue(serializedSession);
+
+      const result = await redisCache.getSchedulingSession("test-session-id");
+
+      expect(result).toBeDefined();
+      expect(result?.id).toBe("test-session-id");
+      expect(result?.results?.availableSlots[0].start).toBeInstanceOf(Date);
+      expect(result?.preferences.excludedDates).toEqual([]);
+    });
+
+    it("should delete scheduling session successfully", async () => {
+      mockRedis.del.mockResolvedValue(1);
+
+      const result = await redisCache.deleteSchedulingSession(
+        "test-session-id"
+      );
+
+      expect(result).toBe(true);
+      expect(mockRedis.del).toHaveBeenCalledWith(
+        "scheduling_session:test-session-id"
+      );
+    });
+  });
+
+  describe("Utility Operations", () => {
+    it("should extend session expiration successfully", async () => {
+      mockRedis.expire.mockResolvedValue(1);
+
+      const result = await redisCache.extendSessionExpiration(
+        "test-session-id",
+        "upload"
+      );
+
+      expect(result).toBe(true);
+      expect(mockRedis.expire).toHaveBeenCalledWith(
+        "upload_session:test-session-id",
+        24 * 60 * 60
+      );
+    });
+
+    it("should get cache statistics", async () => {
+      mockRedis.keys
+        .mockResolvedValueOnce(["upload_session:1", "upload_session:2"])
+        .mockResolvedValueOnce(["scheduling_session:1"])
+        .mockResolvedValueOnce([]);
+
+      const stats = await redisCache.getStats();
+
+      expect(stats).toEqual({
+        totalKeys: 3,
+      });
+    });
+
+    it("should perform health check successfully", async () => {
+      mockRedis.ping.mockResolvedValue("PONG");
+
+      const isHealthy = await redisCache.healthCheck();
+
+      expect(isHealthy).toBe(true);
+      expect(mockRedis.ping).toHaveBeenCalled();
+    });
+
+    it("should handle health check failure", async () => {
+      mockRedis.ping.mockRejectedValue(new Error("Connection failed"));
+
+      const isHealthy = await redisCache.healthCheck();
+
+      expect(isHealthy).toBe(false);
+    });
+  });
+
+  describe("Error Handling", () => {
+    it("should handle JSON parsing errors gracefully", async () => {
+      mockRedis.get.mockResolvedValue("invalid-json");
+
+      const result = await redisCache.getUploadSession("test-session-id");
+
+      expect(result).toBeNull();
+    });
+
+    it("should handle Redis operation failures gracefully", async () => {
+      mockRedis.setex.mockRejectedValue(new Error("Redis error"));
+
+      const result = await redisCache.setUploadSession(
+        "test-session-id",
+        mockUploadSession
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it("should return false when Redis is not available", async () => {
+      delete process.env.UPSTASH_REDIS_REST_URL;
+      const cacheWithoutRedis = new RedisCache();
+
+      const result = await cacheWithoutRedis.setUploadSession(
+        "test-session-id",
+        mockUploadSession
+      );
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/group-meeting-scheduler/src/lib/redis-cache.ts
+++ b/group-meeting-scheduler/src/lib/redis-cache.ts
@@ -1,0 +1,375 @@
+import { Redis } from "@upstash/redis";
+import { SchedulingSession } from "@/types/scheduling";
+import { UploadSession } from "./upload-session";
+
+/**
+ * Redis client instance
+ */
+let redis: Redis | null = null;
+
+/**
+ * Initialize Redis client
+ */
+function getRedisClient(): Redis | null {
+  if (
+    !process.env.UPSTASH_REDIS_REST_URL ||
+    !process.env.UPSTASH_REDIS_REST_TOKEN
+  ) {
+    console.warn("Redis not configured - falling back to in-memory storage");
+    return null;
+  }
+
+  if (!redis) {
+    redis = new Redis({
+      url: process.env.UPSTASH_REDIS_REST_URL,
+      token: process.env.UPSTASH_REDIS_REST_TOKEN,
+    });
+  }
+
+  return redis;
+}
+
+/**
+ * Cache key prefixes
+ */
+const CACHE_KEYS = {
+  UPLOAD_SESSION: "upload_session:",
+  SCHEDULING_SESSION: "scheduling_session:",
+  MEETING_RESULTS: "meeting_results:",
+} as const;
+
+/**
+ * Default expiration times (in seconds)
+ */
+const EXPIRATION = {
+  UPLOAD_SESSION: 24 * 60 * 60, // 24 hours
+  SCHEDULING_SESSION: 24 * 60 * 60, // 24 hours
+  MEETING_RESULTS: 7 * 24 * 60 * 60, // 7 days
+} as const;
+
+/**
+ * Redis cache service for session and meeting data
+ */
+export class RedisCache {
+  private client: Redis | null;
+
+  constructor() {
+    this.client = getRedisClient();
+  }
+
+  /**
+   * Check if Redis is available
+   */
+  isAvailable(): boolean {
+    return this.client !== null;
+  }
+
+  /**
+   * Store upload session data
+   */
+  async setUploadSession(
+    sessionId: string,
+    session: UploadSession
+  ): Promise<boolean> {
+    if (!this.client) return false;
+
+    try {
+      const key = `${CACHE_KEYS.UPLOAD_SESSION}${sessionId}`;
+      const serializedSession = JSON.stringify({
+        ...session,
+        createdAt: session.createdAt.toISOString(),
+        expiresAt: session.expiresAt.toISOString(),
+        participants: session.participants.map((p) => ({
+          ...p,
+          events: p.events.map((e) => ({
+            ...e,
+            start: e.start.toISOString(),
+            end: e.end.toISOString(),
+          })),
+        })),
+        uploadedFiles: session.uploadedFiles.map((f) => ({
+          ...f,
+          uploadedAt: f.uploadedAt.toISOString(),
+        })),
+      });
+
+      await this.client.setex(
+        key,
+        EXPIRATION.UPLOAD_SESSION,
+        serializedSession
+      );
+      return true;
+    } catch (error) {
+      console.error("Failed to store upload session in Redis:", error);
+      return false;
+    }
+  }
+
+  /**
+   * Retrieve upload session data
+   */
+  async getUploadSession(sessionId: string): Promise<UploadSession | null> {
+    if (!this.client) return null;
+
+    try {
+      const key = `${CACHE_KEYS.UPLOAD_SESSION}${sessionId}`;
+      const data = await this.client.get(key);
+
+      if (!data) return null;
+
+      const parsed = JSON.parse(data as string);
+
+      // Convert date strings back to Date objects
+      return {
+        ...parsed,
+        createdAt: new Date(parsed.createdAt),
+        expiresAt: new Date(parsed.expiresAt),
+        participants: parsed.participants.map((p: any) => ({
+          ...p,
+          events: p.events.map((e: any) => ({
+            ...e,
+            start: new Date(e.start),
+            end: new Date(e.end),
+          })),
+        })),
+        uploadedFiles: parsed.uploadedFiles.map((f: any) => ({
+          ...f,
+          uploadedAt: new Date(f.uploadedAt),
+        })),
+      };
+    } catch (error) {
+      console.error("Failed to retrieve upload session from Redis:", error);
+      return null;
+    }
+  }
+
+  /**
+   * Store scheduling session data
+   */
+  async setSchedulingSession(
+    sessionId: string,
+    session: SchedulingSession
+  ): Promise<boolean> {
+    if (!this.client) return false;
+
+    try {
+      const key = `${CACHE_KEYS.SCHEDULING_SESSION}${sessionId}`;
+      const serializedSession = JSON.stringify({
+        ...session,
+        createdAt: session.createdAt.toISOString(),
+        expiresAt: session.expiresAt.toISOString(),
+        participants: session.participants.map((p) => ({
+          ...p,
+          events: p.events.map((e) => ({
+            ...e,
+            start: e.start.toISOString(),
+            end: e.end.toISOString(),
+          })),
+        })),
+        preferences: {
+          ...session.preferences,
+          excludedDates: session.preferences.excludedDates.map((d) =>
+            d.toISOString()
+          ),
+        },
+        results: session.results
+          ? {
+              ...session.results,
+              availableSlots: session.results.availableSlots.map((slot) => ({
+                ...slot,
+                start: slot.start.toISOString(),
+                end: slot.end.toISOString(),
+              })),
+              recommendations: session.results.recommendations.map((slot) => ({
+                ...slot,
+                start: slot.start.toISOString(),
+                end: slot.end.toISOString(),
+              })),
+            }
+          : undefined,
+      });
+
+      await this.client.setex(
+        key,
+        EXPIRATION.SCHEDULING_SESSION,
+        serializedSession
+      );
+      return true;
+    } catch (error) {
+      console.error("Failed to store scheduling session in Redis:", error);
+      return false;
+    }
+  }
+
+  /**
+   * Retrieve scheduling session data
+   */
+  async getSchedulingSession(
+    sessionId: string
+  ): Promise<SchedulingSession | null> {
+    if (!this.client) return null;
+
+    try {
+      const key = `${CACHE_KEYS.SCHEDULING_SESSION}${sessionId}`;
+      const data = await this.client.get(key);
+
+      if (!data) return null;
+
+      const parsed = JSON.parse(data as string);
+
+      // Convert date strings back to Date objects
+      return {
+        ...parsed,
+        createdAt: new Date(parsed.createdAt),
+        expiresAt: new Date(parsed.expiresAt),
+        participants: parsed.participants.map((p: any) => ({
+          ...p,
+          events: p.events.map((e: any) => ({
+            ...e,
+            start: new Date(e.start),
+            end: new Date(e.end),
+          })),
+        })),
+        preferences: {
+          ...parsed.preferences,
+          excludedDates: parsed.preferences.excludedDates.map(
+            (d: string) => new Date(d)
+          ),
+        },
+        results: parsed.results
+          ? {
+              ...parsed.results,
+              availableSlots: parsed.results.availableSlots.map(
+                (slot: any) => ({
+                  ...slot,
+                  start: new Date(slot.start),
+                  end: new Date(slot.end),
+                })
+              ),
+              recommendations: parsed.results.recommendations.map(
+                (slot: any) => ({
+                  ...slot,
+                  start: new Date(slot.start),
+                  end: new Date(slot.end),
+                })
+              ),
+            }
+          : undefined,
+      };
+    } catch (error) {
+      console.error("Failed to retrieve scheduling session from Redis:", error);
+      return null;
+    }
+  }
+
+  /**
+   * Delete upload session
+   */
+  async deleteUploadSession(sessionId: string): Promise<boolean> {
+    if (!this.client) return false;
+
+    try {
+      const key = `${CACHE_KEYS.UPLOAD_SESSION}${sessionId}`;
+      const result = await this.client.del(key);
+      return result > 0;
+    } catch (error) {
+      console.error("Failed to delete upload session from Redis:", error);
+      return false;
+    }
+  }
+
+  /**
+   * Delete scheduling session
+   */
+  async deleteSchedulingSession(sessionId: string): Promise<boolean> {
+    if (!this.client) return false;
+
+    try {
+      const key = `${CACHE_KEYS.SCHEDULING_SESSION}${sessionId}`;
+      const result = await this.client.del(key);
+      return result > 0;
+    } catch (error) {
+      console.error("Failed to delete scheduling session from Redis:", error);
+      return false;
+    }
+  }
+
+  /**
+   * Update session expiration
+   */
+  async extendSessionExpiration(
+    sessionId: string,
+    type: "upload" | "scheduling"
+  ): Promise<boolean> {
+    if (!this.client) return false;
+
+    try {
+      const prefix =
+        type === "upload"
+          ? CACHE_KEYS.UPLOAD_SESSION
+          : CACHE_KEYS.SCHEDULING_SESSION;
+      const expiration =
+        type === "upload"
+          ? EXPIRATION.UPLOAD_SESSION
+          : EXPIRATION.SCHEDULING_SESSION;
+      const key = `${prefix}${sessionId}`;
+
+      const result = await this.client.expire(key, expiration);
+      return result === 1;
+    } catch (error) {
+      console.error("Failed to extend session expiration:", error);
+      return false;
+    }
+  }
+
+  /**
+   * Get cache statistics
+   */
+  async getStats(): Promise<{
+    totalKeys: number;
+    memoryUsage?: string;
+  } | null> {
+    if (!this.client) return null;
+
+    try {
+      // Get keys matching our patterns
+      const uploadKeys = await this.client.keys(
+        `${CACHE_KEYS.UPLOAD_SESSION}*`
+      );
+      const schedulingKeys = await this.client.keys(
+        `${CACHE_KEYS.SCHEDULING_SESSION}*`
+      );
+      const meetingKeys = await this.client.keys(
+        `${CACHE_KEYS.MEETING_RESULTS}*`
+      );
+
+      return {
+        totalKeys:
+          uploadKeys.length + schedulingKeys.length + meetingKeys.length,
+      };
+    } catch (error) {
+      console.error("Failed to get cache stats:", error);
+      return null;
+    }
+  }
+
+  /**
+   * Health check for Redis connection
+   */
+  async healthCheck(): Promise<boolean> {
+    if (!this.client) return false;
+
+    try {
+      const result = await this.client.ping();
+      return result === "PONG";
+    } catch (error) {
+      console.error("Redis health check failed:", error);
+      return false;
+    }
+  }
+}
+
+/**
+ * Singleton instance
+ */
+export const redisCache = new RedisCache();


### PR DESCRIPTION
- Add POST /api/meetings/analyze endpoint for scheduling analysis
- Implement Redis caching layer with Upstash Redis integration
- Update session management to support async Redis operations
- Add comprehensive API tests for meeting analysis endpoints
- Add Redis cache tests with error handling and fallback scenarios
- Update existing calendar API endpoints to work with async sessions
- Add environment configuration example for Redis setup
- All tests passing (212 tests)

Addresses requirements 3.1, 3.2, 3.3, 3.4, and 6.4